### PR TITLE
Add handleStyle property to resizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,13 @@ The `customClass` property is used to set the custom `className` of a resizable 
 
 The `customStyle` property is used to set the custom `classStyle` of a resizable component.
 
+#### handleStyle: PropTypes.shape({ x: PropTypes.object, y: PropTypes.object, xy: PropTypes.object })
+
+The `handleStyle` property is used to override the style of one or more resize handles.
+Only the axis you specify will have its handle style replaced.
+If you specify a value for `x` it will completely replace the styles for the X resize handle,
+but the `y` and `xy` handle will still use the default styles.
+
 #### `isResizable`: Proptypes.shape({ x: PropTypes.bool, y: PropTypes.bool, xy: PropTypes.bool })
 
 The `isResizable` property is used to set the resizable permission of a resizable component.

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,11 @@ export default class Risizable extends Component {
     onTouchStart: PropTypes.func,
     onResize: PropTypes.func,
     customStyle: PropTypes.object,
+    handleStyle: PropTypes.shape({
+      x: PropTypes.object,
+      y: PropTypes.object,
+      xy: PropTypes.object,
+    }),
     isResizable: PropTypes.shape({
       x: PropTypes.bool,
       y: PropTypes.bool,
@@ -34,6 +39,7 @@ export default class Risizable extends Component {
     onResizeStop: () => null,
     isResizable: { x: true, y: true, xy: true },
     customStyle: {},
+    handleStyle: {},
   }
 
   constructor(props) {
@@ -152,7 +158,7 @@ export default class Risizable extends Component {
       width: this.state.width ? `${this.state.width}px` : '',
       height: this.state.height ? `${this.state.height}px` : '',
     };
-    const { isResizable, onClick, customStyle, customClass,
+    const { isResizable, onClick, customStyle, handleStyle, customClass,
             onMouseDown, onDoubleClick, onTouchStart } = this.props;
     const onResizeStartX = this.onResizeStart.bind(this, 'x');
     const onResizeStartY = this.onResizeStart.bind(this, 'y');
@@ -170,21 +176,20 @@ export default class Risizable extends Component {
         {this.props.children}
         {
           isResizable.x !== false
-            ? <Resizer type={'x'} onResizeStart={onResizeStartX} />
+            ? <Resizer type={'x'} onResizeStart={onResizeStartX} replaceStyles={handleStyle.x} />
             : null
         }
         {
           isResizable.y !== false
-            ? <Resizer type={'y'} onResizeStart={onResizeStartY} />
+            ? <Resizer type={'y'} onResizeStart={onResizeStartY} replaceStyles={handleStyle.y} />
             : null
         }
         {
           isResizable.xy !== false
-            ? <Resizer type={'xy'} onResizeStart={onResizeStartXY} />
+            ? <Resizer type={'xy'} onResizeStart={onResizeStartXY} replaceStyles={handleStyle.xy} />
             : null
         }
       </div>
     );
   }
 }
-

--- a/src/resizer.js
+++ b/src/resizer.js
@@ -31,17 +31,25 @@ export default class Resizer extends Component {
   static propTypes = {
     onResizeStart: PropTypes.func,
     type: PropTypes.oneOf(['x', 'y', 'xy']).isRequired,
+    replaceStyles: PropTypes.object,
   }
 
   onTouchStart(event) {
     this.props.onResizeStart(event.touches[0]);
   }
 
+  getStyle() {
+    if (this.props.replaceStyles) {
+      return this.props.replaceStyles;
+    }
+    return { ...styles.base, ...styles[this.props.type] };
+  }
+
   render() {
     const onTouchStart = this.onTouchStart.bind(this);
     return (
       <div
-        style={{ ...styles.base, ...styles[this.props.type] }}
+        style={this.getStyle()}
         onMouseDown={this.props.onResizeStart}
         onTouchStart={onTouchStart}
       />


### PR DESCRIPTION
Allows someone to replace the handle style with any style they want. They can replace each style individually and it will use the default for the other handles.

Useful for making visible handles or changing the width of handles to tweak usability.

I started this because I want to have a box attached to the bottom of the screen and allow vertical resize with a handle at the top of the box. By the time I finished, I realized that I would also have to reverse how the amount is calculated, but this could be useful anyway so I will make a different PR to deal with my case and submit this one anyway.