### PR TITLE
Support preserving auto size

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -81,11 +81,6 @@ export default class Resizable extends Component {
     const { width, height } = props;
     this.state = {
       isActive: false,
-      width: typeof width === 'undefined' ? 'auto' : width,
-      height: typeof height === 'undefined' ? 'auto' : height,
-    };
-    this.state = {
-      isActive: false,
       width,
       height,
     };

--- a/src/index.js
+++ b/src/index.js
@@ -226,7 +226,7 @@ export default class Resizable extends Component {
 
   getBoxStyle() {
     const getSize = key => {
-      if (typeof this.state[key] === 'undefined') return 'auto';
+      if (typeof this.state[key] === 'undefined' || this.state[key] === 'auto') return 'auto';
       else if (/px$/.test(this.state[key].toString())) return this.state[key];
       else if (/%$/.test(this.state[key].toString())) return this.state[key];
       return `${this.state[key]}px`;

--- a/src/index.js
+++ b/src/index.js
@@ -81,6 +81,11 @@ export default class Resizable extends Component {
     const { width, height } = props;
     this.state = {
       isActive: false,
+      width: typeof width === 'undefined' ? 'auto' : width,
+      height: typeof height === 'undefined' ? 'auto' : height,
+    };
+    this.state = {
+      isActive: false,
       width,
       height,
     };
@@ -121,7 +126,7 @@ export default class Resizable extends Component {
   }
 
   onMouseMove({ clientX, clientY }) {
-    const { direction, original, isActive } = this.state;
+    const { direction, original, isActive, width, height } = this.state;
     const { minWidth, maxWidth, minHeight, maxHeight } = this.props;
     if (!isActive) return;
     let newWidth = original.width;
@@ -154,7 +159,10 @@ export default class Resizable extends Component {
       newHeight = clamp(newHeight, min, max);
       newHeight = snap(newHeight, this.props.grid[1]);
     }
-    this.setState({ width: newWidth, height: newHeight });
+    this.setState({
+      width: width !== 'auto' ? newWidth : 'auto',
+      height: height !== 'auto' ? newHeight : 'auto',
+    });
     const resizable = this.refs.resizable;
     const styleSize = {
       width: newWidth || this.state.width,

--- a/test/test-resize-box.js
+++ b/test/test-resize-box.js
@@ -36,6 +36,16 @@ describe('Resizable Component test', () => {
     done();
   });
 
+  it('Should box width and height equal auto', (done) => {
+    const resizable = TestUtils.renderIntoDocument(<Resizable width="auto" height="auto" />);
+    const divs = TestUtils.scryRenderedDOMComponentsWithTag(resizable, 'div');
+    assert.equal(divs.length, 9);
+    assert.equal(divs[0].style.width, 'auto');
+    assert.equal(divs[0].style.height, 'auto');
+    assert.equal(divs[0].style.position, 'relative');
+    done();
+  });
+
   it('Should style is applied to box', (done) => {
     const resizable = TestUtils.renderIntoDocument(
       <Resizable customStyle={{ position: 'absolute' }} />


### PR DESCRIPTION
It enables a resizable box to keep a flexible dimension for width and height.
For example:

```JSX
<Resizable
    width={100}
    height="auto"
    isResizable={ { right: true } }
/>
```

With this auto property, the box will preserve `height: auto` style after resizing its width.