### PR TITLE
Fixing issue on resizing with touch events

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -215,6 +215,7 @@ export default class Resizable extends Component {
   }
 
   onResizeStart(direction, e) {
+    const ev = e.touches ? e.touches[0] : e;
     const clientSize = {
       width: this.refs.resizable.clientWidth,
       height: this.refs.resizable.clientHeight,
@@ -223,8 +224,8 @@ export default class Resizable extends Component {
     const size = this.getBoxSize();
     this.setState({
       original: {
-        x: e.clientX,
-        y: e.clientY,
+        x: ev.clientX,
+        y: ev.clientY,
         width: size.width,
         height: size.height,
       },

--- a/src/resizer.js
+++ b/src/resizer.js
@@ -88,7 +88,7 @@ export default class Resizer extends Component {
   }
 
   onTouchStart(event) {
-    this.props.onResizeStart(event.touches[0]);
+    this.props.onResizeStart(event);
   }
 
   getStyle() {

--- a/test/test-resizer.js
+++ b/test/test-resizer.js
@@ -18,7 +18,7 @@ describe('Resizer Component test', () => {
 
   it('Should call onResizeStart, when touch start', (done) => {
     const onResizeStart = e => {
-      assert.equal(e.clientX, 200);
+      assert.equal(e.touches[0].clientX, 200);
       done();
     };
     const resizer = TestUtils.renderIntoDocument(


### PR DESCRIPTION
@bokuweb 
Related to https://github.com/bokuweb/react-rnd/issues/58

To change that `onTouchStart` method passing the whole event (as we discussed) I need to do adapt the `onResizeStart` method as well. And the test.

What do you think?