### PR TITLE
Fixes typescript error with react children dom elements

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -43,7 +43,6 @@ export type ResizeStartCallBack = (
 ) => void;
 
 export interface ResizableProps {
-  children?: React.ReactChildren;
   onResizeStop?: ResizeHandler;
   onResizeStart?: ResizeStartCallBack;
   onResize?: ResizeHandler;


### PR DESCRIPTION
This pull request fixes a typescript error, where it's not possible to add DOM elements as children. For example
```js
<Resizable><div>Test</div></Resizable>
```
throws **Type 'Element[]' is not assignable to type 'ReactChildren | undefined'.**

`ResizableProps` in the typescript definition file has the `children` property as `ReactChildren` defined.
This should be `React.ReactNode` instead. We can remove it's definition completely as it is already defined in `React.Component`, which `Resizable` extends.